### PR TITLE
Missing 'or'

### DIFF
--- a/examples/operator.md
+++ b/examples/operator.md
@@ -62,9 +62,9 @@ hello world
 
 - `==` equal to
 
-- `>=` greater than equal to
+- `>=` greater than or equal to
 
-- `<=` lesser than equal to
+- `<=` lesser than or equal to
 
 - `!=` not equal to
 


### PR DESCRIPTION
Without the or, 'greater than equal' means the same as 'greater than' but excludes equal. On the other hand, 'greater than or equal' means it could be greater than or it could be equal.