### PR TITLE
update variadic function, fix typo & improve grammar

### DIFF
--- a/examples/functions/functions.md
+++ b/examples/functions/functions.md
@@ -79,7 +79,7 @@ Tom , 15
 
 ## High Order Functions
 
-Functions in V can also take in another function which is usually needed to sort, map, fitler etc.
+Functions in V can also take in another function as a parameter which is usually needed for something like sort, map, filter, etc.
 
 ```go
 fn square(num int) int {

--- a/examples/functions/functions.md
+++ b/examples/functions/functions.md
@@ -38,7 +38,9 @@ fn main() {
 }
 
 fn foo(test ...string) {
-	println(test)
+	for txt in test {
+		println(txt)
+	}
 }
 ```
 

--- a/examples/loops/loops.md
+++ b/examples/loops/loops.md
@@ -47,7 +47,7 @@ for {
 println(counter)
 ```
 
-Output:
+Output
 
 ```bash
 120

--- a/examples/struct/struct.md
+++ b/examples/struct/struct.md
@@ -6,15 +6,15 @@ For people coming from OOP languages, it can be thought as class but with more r
 
 ```go
 struct User {
-    name string
-    email string
-    country string
+   name string
+   email string
+   country string
 }
 
 user := User {
-    name: "V developers"
-    email: "developers@vlang.io"
-    country: "Canada"
+   name: "V developers"
+   email: "developers@vlang.io"
+   country: "Canada"
 }
 
 println(user.country)
@@ -22,7 +22,7 @@ println(user.country)
 
 > Note: Structs are allocated on the stack.
 
-### `&` prefix
+### The `&` prefix
 
 You can allocate a struct on the heap and get a reference to it by using the `&` prefix as follows:
 
@@ -39,7 +39,7 @@ Struct fields are `private` and `immutable` by default. Their access modifiers c
 
 ```go
 struct User {
-    email string
+   email string
 }
 ```
 


### PR DESCRIPTION
The old code is not work
```go
fn main() {
	foo("V", "is", "the", "best", "lang" , "ever")
}

fn foo(test ...string) {
	println(test)
}
```
This will got error
```go
:14:19: cannot use type `byte*` as type `string` in first argument to `write()`
   12|     sb.write("[")
   13|     for i, elm in a {
   14|         sb.write(elm.str())
                               ^
   15|         if i < a.len - 1 {
   16|             sb.write(", ")
```