### PR TITLE
Adding portuguese to .typo-ci.yml file

### DIFF
--- a/.typo-ci.yml
+++ b/.typo-ci.yml
@@ -1,6 +1,7 @@
 dictionaries:
   - en
   - en_GB
+  - pt
 
 # Files to exclude
 excluded_files:


### PR DESCRIPTION
As mentioned in https://github.com/v-community/v_by_example/pull/108#issuecomment-562935223 I've added support to Typo CI for Portuguese :D

You have two options for which type of Portuguese, either `pt` or `pt_BR`.

Thank you for this suggestion :D