### PR TITLE
Fix errors in en/de/pt-br

### DIFF
--- a/de/examples/section_2/operator.md
+++ b/de/examples/section_2/operator.md
@@ -85,9 +85,9 @@ hello world
 
 ## Bitwise Operators
 
-- `>>` bitshift links
+- `<<` bitshift links
 
-- `<<` bitshift rechts
+- `>>` bitshift rechts
 
 - `&` bitweises Und
 

--- a/de/examples/section_4/array-functions.md
+++ b/de/examples/section_4/array-functions.md
@@ -32,7 +32,7 @@ array.delete(ix int)
 Deletes the element present in the array at index `ix`.
 
 ```go
-mut even_numbers = [2, 4, 6, 8, 10]
+mut even_numbers := [2, 4, 6, 8, 10]
 even_numbers.delete(3)
 println(even_numbers)
 ```

--- a/en/examples/section_2/operator.md
+++ b/en/examples/section_2/operator.md
@@ -82,9 +82,9 @@ hello world
 
 ## Bitwise Operators
 
-- `>>` left bitshift
+- `<<` left bitshift
 
-- `<<` right bitshift
+- `>>` right bitshift
 
 - `&` bitwise and
 

--- a/en/examples/section_4/array-functions.md
+++ b/en/examples/section_4/array-functions.md
@@ -26,7 +26,7 @@ array.delete(ix type)
 Deletes the element present in the array at index `ix`.
 
 ```go
-mut even_numbers = [2, 4, 6, 8, 10]
+mut even_numbers := [2, 4, 6, 8, 10]
 even_numbers.delete(3)
 println(even_numbers) // [2, 4, 6, 10]
 ```

--- a/pt-br/examples/section_2/operators.md
+++ b/pt-br/examples/section_2/operators.md
@@ -82,9 +82,9 @@ Olá Mundo
 
 ## Operadores bit a bit
 
-- `>>` left bitshift
+- `<<` left bitshift
 
-- `<<` right bitshift
+- `>>` right bitshift
 
 - `&` bitwise and
 


### PR DESCRIPTION
I have translated the repo to Japanese and found the following small errors.

* bitwise operators are inversed: ( see https://github.com/vlang/v/blob/master/vlib/v/token/token.v#L201 )

```markdown
## Bitwise Operators

- `<<` left bitshift        -- should be `>>`

- `>>` right bitshift     -- should be `<<`
```

* missing `:`:

```go
mut even_numbers = [2, 4, 6, 8, 10]      // `=` should be `:=`
even_numbers.delete(3)
println(even_numbers) // [2, 4, 6, 10]
```

The errors have been propagated to other locales partiall: de/pt-br/id.
I fixed them as well.

I'd be glad if you'd merge this before I send the ja translation.

Thank you, 